### PR TITLE
chore: update domain from allons-y.llc to allons-y.studio

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,8 @@ jobs:
           node-version: [24]
 
       steps:
-        - uses: actions/checkout@v6
+        - name: Check out code
+          uses: actions/checkout@v6
           with:
             persist-credentials: false
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.0",
   "description": "Prepends licensing information to CSS files",
   "license": "Apache-2.0",
-  "author": "Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.llc)",
+  "author": "Cassondra Roberts <castastrophe@users.noreply.github.com> (https://allons-y.studio)",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/castastrophe/postcss-licensing.git"


### PR DESCRIPTION
## What
Update domain references from `allons-y.llc` to `allons-y.studio`.

## Why
Studio rebrand — the `.llc` domain is being retired in favour of `.studio`.

## How
Find-and-replace author URL in `package.json`.

## Test plan
Verified no remaining `allons-y.llc` references in source files (excluding `.git` and `node_modules`).

## Checklist
- [x] My code follows the project's style and conventions.
- [x] I have performed a self-review of my changes.
- [ ] I have added or updated tests where appropriate.
- [x] I have updated documentation where appropriate.
- [x] My changes generate no new warnings or accessibility regressions.
- [x] I have read the [Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md).
