### PR TITLE
chore: remove leftover semantic-release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "postpack": "pinst --enable",
     "prepack": "pinst --disable",
     "prepare": "husky && envoy || true",
-    "semantic-release": "semantic-release",
     "test": "ava"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- Remove the `semantic-release` npm script from `package.json` — it had no corresponding devDependency and was leftover cruft from the migration to Changesets.
- Confirmed no other references to `semantic-release` or `commitlint` remain anywhere in the repo (no `.releaserc`, no commitlint config, no workflow references).

## Test plan
- [x] `yarn test` passes (ran automatically via pre-commit hook)